### PR TITLE
Add badge strings to profiles

### DIFF
--- a/profiles/0d02d00e-eac4-4cdd-b92e-1e75eb03af6b/index.json
+++ b/profiles/0d02d00e-eac4-4cdd-b92e-1e75eb03af6b/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Plastic Death",
     "description": "Delve into this ambitious album of contemplative prog and art rock songs. Charts brought to you by ImPhanty.",
+    "badge": "YARN",
     "iconUrl": "https://releases.yarg.in/profiles/0d02d00e-eac4-4cdd-b92e-1e75eb03af6b/icon.png",
     "bannerBackUrl": "https://releases.yarg.in/profiles/0d02d00e-eac4-4cdd-b92e-1e75eb03af6b/banner.png",
     "initialRelease": "2025-07-20T16:21:33.3063029Z",

--- a/profiles/1893d384-cc12-435b-aa64-a774acf77ee0/index.json
+++ b/profiles/1893d384-cc12-435b-aa64-a774acf77ee0/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Classical Keys Pack 1",
     "description": "Explore world-famous pieces for piano, organ, and even calliope with YARG\u0027s first collection of public domain classical music. Learn authentic right-hand parts on Pro Keys, or play five-lane versions of each hand on Keys and Bass!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistKeys.png",
     "bannerBackUrl": "@/banners/SetlistKeysAlt.png",
     "initialRelease": "2024-10-23T02:02:51.396Z",

--- a/profiles/196e82d2-e919-4bf7-8db6-6216f26e5f7c/index.json
+++ b/profiles/196e82d2-e919-4bf7-8db6-6216f26e5f7c/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Mini-Wave 0",
     "description": "An exclusive early sneak peek into our biggest chart launch to date, featuring some of the best songs you\u0027ve never heard of!",
+    "badge": "YARN",
     "iconUrl": "@/icons/SetlistNetwork.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "initialRelease": "2025-04-01T17:33:31.8406513Z",

--- a/profiles/1faac656-ec58-4aeb-817f-62111a79ec38/index.json
+++ b/profiles/1faac656-ec58-4aeb-817f-62111a79ec38/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "YARN Pack 2",
     "description": "The second grab-bag pack of charts from music artists and charters in the YARG community!",
+    "badge": "YARN",
     "iconUrl": "@/icons/SetlistNetwork.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "initialRelease": "2025-07-09T14:12:52.9942264Z",

--- a/profiles/2475f77d-d4a3-4393-8f45-6a89948f8b9c/index.json
+++ b/profiles/2475f77d-d4a3-4393-8f45-6a89948f8b9c/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "SUMMERTIDE",
     "description": "Keep summer in your heart with this brilliant pop and electronic album from Alohaii. Expect a challenge on vocals with these ten songs, featuring ten different virtual singers and Vtubers!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistSummertide.png",
     "bannerBackUrl": "@/banners/SetlistSummertide.png",
     "initialRelease": "2024-09-12T00:12:40.033Z",

--- a/profiles/2d78800c-1397-496a-83c1-50759607999a/index.json
+++ b/profiles/2d78800c-1397-496a-83c1-50759607999a/index.json
@@ -4,6 +4,7 @@
     "metadata": {
         "name": "YARG",
         "description": "YARG (a.k.a. Yet Another Rhythm Game) is a free, open-source, plastic guitar game that is still in development. It supports guitar (five fret), drums (plastic or e-kit), vocals, pro-keys, and more!",
+        "badge": "Official",
         "releaseName": "Stable",
         "iconUrl": "@/icons/Stable.png",
         "bannerBackUrl": "@/banners/Stable.png",

--- a/profiles/30a9b33a-72bf-4a42-afa2-188a862f34c3/index.json
+++ b/profiles/30a9b33a-72bf-4a42-afa2-188a862f34c3/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "FX4",
     "description": "Ported from the setlist Zero Gravity 3D: the 10-track chiptune epic FX4 by Jake \u0022virt\u0022 Kaufman. Charts brought to you by 3-UP.",
+    "badge": "YARN",
     "iconUrl": "https://releases.yarg.in/profiles/30a9b33a-72bf-4a42-afa2-188a862f34c3/fx4.png",
     "bannerBackUrl": "https://releases.yarg.in/profiles/30a9b33a-72bf-4a42-afa2-188a862f34c3/banner_fx4.jpg",
     "initialRelease": "2025-06-28T23:40:04.6348917Z",

--- a/profiles/35dc0e7e-e9b5-49f3-881d-8dbed8678dc7/index.json
+++ b/profiles/35dc0e7e-e9b5-49f3-881d-8dbed8678dc7/index.json
@@ -4,6 +4,7 @@
     "metadata": {
         "name": "YARG",
         "description": "YARG Nightly (a.k.a. YARG bleeding-edge) is an alternative version of YARG that is updated twice a day (if changes have been made). These builds are in an extremely early beta, so bugs are expected. If you do notice a bug, please be sure to report it on GitHub, or on our Discord.",
+        "badge": "Official",
         "releaseName": "Nightly",
         "iconUrl": "@/icons/Nightly.png",
         "bannerBackUrl": "@/banners/Nightly.png",

--- a/profiles/46259f93-3550-4105-8816-cd96e167c560/index.json
+++ b/profiles/46259f93-3550-4105-8816-cd96e167c560/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Assorted Rock 1",
     "description": "Join us for our first pack of DLC with a collection of indie performances and electronic rock tracks!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistDLC.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "initialRelease": "2024-08-24T16:50:34.439Z",

--- a/profiles/49d5c1e5-ef1b-49af-a710-ebccdf5e940b/index.json
+++ b/profiles/49d5c1e5-ef1b-49af-a710-ebccdf5e940b/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Christmas Keys 1",
     "description": "Ring in the holiday season with six public domain Christmas classics. Learn authentic right-hand parts on Pro Keys, or play five-lane versions of each hand on Keys and Bass!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistKeys.png",
     "bannerBackUrl": "@/banners/SetlistKeysChristmas.png",
     "initialRelease": "2024-12-16T02:43:35.292Z",

--- a/profiles/77385a95-215f-486b-bbf7-c2d21ae33ea6/index.json
+++ b/profiles/77385a95-215f-486b-bbf7-c2d21ae33ea6/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Assorted Electronic 1",
     "description": "Here is a pack of energetic pop/dance/electronic songs, providing challenges on all instruments!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistDLC.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "initialRelease": "2024-08-30T01:17:59.492Z",

--- a/profiles/8474d8ad-15bd-492c-927b-003940100fa1/index.json
+++ b/profiles/8474d8ad-15bd-492c-927b-003940100fa1/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "YARG Official Setlist",
     "description": "YARG\u0027s Official Setlist is a multi-genre, full-band full-difficulty, in development setlist brought to you by YARG\u0027s amazing and talented charting team. Its eventual goal is to have 80 to 100 songs, all made with love and lots of care. The setlist contains songs from underappreciated artists, along with more well known songs.",
+    "badge": "Official",
     "iconUrl": "@/icons/Setlist.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "bannerFrontUrl": "@/banners/SetlistFront.png",

--- a/profiles/9b0beeae-196f-457b-9d9e-279499992e4a/index.json
+++ b/profiles/9b0beeae-196f-457b-9d9e-279499992e4a/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "WANDERKID",
     "description": "Follow the journey of WANDERKID in JW Francis\u0027s sophomore album! Escape with warm lo-fi indie rock vibes and nostalgically jangly guitar.",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistWanderkid.png",
     "bannerBackUrl": "@/banners/SetlistWanderkid.png",
     "initialRelease": "2024-09-30T23:13:26.753Z",

--- a/profiles/a76b8109-8390-41a9-825e-f9790ef435f4/index.json
+++ b/profiles/a76b8109-8390-41a9-825e-f9790ef435f4/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Abyss of Time",
     "description": "Take on challenging charts of 15 tracks from James Paddock\u0027s metal album, courtesy of Keagan Dunn.",
+    "badge": "YARN",
     "iconUrl": "https://releases.yarg.in/profiles/a76b8109-8390-41a9-825e-f9790ef435f4/abyss_of_time.png",
     "bannerBackUrl": "https://releases.yarg.in/profiles/a76b8109-8390-41a9-825e-f9790ef435f4/banner_abyssoftime.jpg",
     "initialRelease": "2025-06-28T23:32:51.2597638Z",

--- a/profiles/c0a10224-2cf2-4584-8dee-778108c7796d/index.json
+++ b/profiles/c0a10224-2cf2-4584-8dee-778108c7796d/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Assorted Metal 1",
     "description": "Rock out with an assortment of accessible metal songs, drawing from nu-metal, alternative, thrash, and djent!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistDLC.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "initialRelease": "2025-03-01T19:45:26.4850637Z",

--- a/profiles/c0eb74f4-05df-4dfa-8ceb-b699ced444fc/index.json
+++ b/profiles/c0eb74f4-05df-4dfa-8ceb-b699ced444fc/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "The Slip",
     "description": "Round out \u0022Discipline\u0022 from the official setlist with the rest of Nine Inch Nails\u0027 seventh album, featuring famous tracks that range from caustic and intense to eerie and meditative.",
+    "badge": "Official",
     "iconUrl": "https://releases.yarg.in/profiles/c0eb74f4-05df-4dfa-8ceb-b699ced444fc/icon.png",
     "bannerBackUrl": "https://releases.yarg.in/profiles/c0eb74f4-05df-4dfa-8ceb-b699ced444fc/banner.png",
     "initialRelease": "2025-07-25T16:19:46.1761723Z",

--- a/profiles/ca41fee5-35de-442e-8e28-c246e19b36fc/index.json
+++ b/profiles/ca41fee5-35de-442e-8e28-c246e19b36fc/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Children's Keys Pack 1",
     "description": "If you have a budding pianist in your life (or if the classical songs are too hard for you), try this easy pack of classic children's songs and nursery rhymes. Learn real melodies on Pro Keys, or play five-lane versions of both the melody and harmony with the Keys and Bass parts.",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistKeys.png",
     "bannerBackUrl": "@/banners/SetlistKeys.png",
     "initialRelease": "2024-10-23T02:02:51.396Z",

--- a/profiles/dc81038a-4bd8-4bc3-a9e7-e7a2adcd5d92/index.json
+++ b/profiles/dc81038a-4bd8-4bc3-a9e7-e7a2adcd5d92/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "YARN Pack 1",
     "description": "Our first grab-bag pack from YARN authors. Check out what they\u0027ve submitted!",
+    "badge": "YARN",
     "iconUrl": "@/icons/SetlistNetwork.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "initialRelease": "2025-03-08T18:24:31.3334654Z",

--- a/profiles/e8b80fab-7ea9-4b83-bfcc-a0ac4c6fa080/index.json
+++ b/profiles/e8b80fab-7ea9-4b83-bfcc-a0ac4c6fa080/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Children\u0027s Keys Pack 2",
     "description": "Hungarian Rhapsody No. 2 too hard for you? These 6 classic children\u0027s tunes are great entry point for budding pianists. Learn the real right-hand parts on Pro Keys, or play five-lane versions of both hands on Keys and Bass!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistKeys.png",
     "bannerBackUrl": "@/banners/SetlistKeys.png",
     "initialRelease": "2025-05-02T17:42:06.5359047Z",

--- a/profiles/f9eda7ad-0ec5-4782-bc5a-f3b5c46aa2c8/index.json
+++ b/profiles/f9eda7ad-0ec5-4782-bc5a-f3b5c46aa2c8/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Assorted Rock 2",
     "description": "Cozy and fuzzy is the theme of this second assortment of rock songs, which range in genre from pop-rock to progressive metal.",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistDLC.png",
     "bannerBackUrl": "@/banners/SetlistBack.png",
     "initialRelease": "2025-07-12T17:48:35.5922995Z",

--- a/profiles/fcbd2956-cffe-4ede-959f-177bb634743f/index.json
+++ b/profiles/fcbd2956-cffe-4ede-959f-177bb634743f/index.json
@@ -4,6 +4,7 @@
   "metadata": {
     "name": "Classical Keys Pack 2",
     "description": "Classical Keys is back with 6 more public domain pieces for piano and accordion. Learn the real right-hand parts on Pro Keys, or play five-lane versions of each hand on Keys and Bass!",
+    "badge": "Official",
     "iconUrl": "@/icons/SetlistKeys.png",
     "bannerBackUrl": "@/banners/SetlistKeysAlt.png",
     "initialRelease": "2025-05-02T17:31:34.4652562Z",

--- a/profiles/index.json
+++ b/profiles/index.json
@@ -3,12 +3,13 @@
     "backgroundUrl": "@/banners/SetlistWave.png",
     "backgroundAccent": "#DF6B00",
     "useLightText": false,
-    "preHeaderText": "YARG\u0027s Third DLC",
-    "headerText": "Assorted Metal 1",
-    "viewProfileUUID": "c0a10224-2cf2-4584-8dee-778108c7796d",
+    "preHeaderText": "Official Setlist",
+    "headerText": "Wave 11",
+    "viewProfileUUID": "8474d8ad-15bd-492c-927b-003940100fa1",
+    "previewUrl": "https://www.youtube.com/watch?v=pLro3rQ3KA4",
     "localeOverrides": {}
   },
-  "lastUpdated": "2025-07-25T16:19:46.1761723Z",
+  "lastUpdated": "2025-08-04T11:57:29.1761723Z",
   "profiles": [
     {
       "uuid": "2d78800c-1397-496a-83c1-50759607999a",
@@ -138,7 +139,7 @@
     {
       "uuid": "dc81038a-4bd8-4bc3-a9e7-e7a2adcd5d92",
       "type": "setlist",
-      "category": "official_setlist",
+      "category": "yarn_setlist",
       "url": "https://releases.yarg.in/profiles/dc81038a-4bd8-4bc3-a9e7-e7a2adcd5d92/",
       "release": "2025-03-08T18:24:31.3334654Z",
       "name": "YARN Pack 1",
@@ -149,7 +150,7 @@
     {
       "uuid": "196e82d2-e919-4bf7-8db6-6216f26e5f7c",
       "type": "setlist",
-      "category": "official_setlist",
+      "category": "yarn_setlist",
       "url": "https://releases.yarg.in/profiles/196e82d2-e919-4bf7-8db6-6216f26e5f7c/",
       "release": "2025-04-01T17:33:31.8406513Z",
       "name": "Mini-Wave 0",
@@ -182,29 +183,31 @@
     {
       "uuid": "a76b8109-8390-41a9-825e-f9790ef435f4",
       "type": "setlist",
-      "category": "official_setlist",
+      "category": "yarn_setlist",
       "url": "https://releases.yarg.in/profiles/a76b8109-8390-41a9-825e-f9790ef435f4/",
       "release": "2025-06-28T23:32:51.2597638Z",
       "name": "Abyss of Time",
-      "iconUrl": "@/icons/SetlistNetwork.png",
-      "bannerUrl": "@/banners/SetlistBack.png",
+      "subText": "James Paddock",
+      "iconUrl": "https://releases.yarg.in/profiles/a76b8109-8390-41a9-825e-f9790ef435f4/abyss_of_time.png",
+      "bannerUrl": "https://releases.yarg.in/profiles/a76b8109-8390-41a9-825e-f9790ef435f4/banner_abyssoftime.jpg",
       "localeOverrides": {}
     },
     {
       "uuid": "30a9b33a-72bf-4a42-afa2-188a862f34c3",
       "type": "setlist",
-      "category": "official_setlist",
+      "category": "yarn_setlist",
       "url": "https://releases.yarg.in/profiles/30a9b33a-72bf-4a42-afa2-188a862f34c3/",
       "release": "2025-06-28T23:40:04.6348917Z",
       "name": "FX4",
-      "iconUrl": "@/icons/SetlistNetwork.png",
-      "bannerUrl": "@/banners/SetlistBack.png",
+      "subText": "Jake \"virt\" Kaufman",
+      "iconUrl":	"https://releases.yarg.in/profiles/30a9b33a-72bf-4a42-afa2-188a862f34c3/fx4.png",
+      "bannerUrl": "https://releases.yarg.in/profiles/30a9b33a-72bf-4a42-afa2-188a862f34c3/banner_fx4.jpg",
       "localeOverrides": {}
     },
     {
       "uuid": "1faac656-ec58-4aeb-817f-62111a79ec38",
       "type": "setlist",
-      "category": "official_setlist",
+      "category": "yarn_setlist",
       "url": "https://releases.yarg.in/profiles/1faac656-ec58-4aeb-817f-62111a79ec38/",
       "release": "2025-07-09T14:12:52.9942264Z",
       "name": "YARN Pack 2",
@@ -226,10 +229,11 @@
     {
       "uuid": "0d02d00e-eac4-4cdd-b92e-1e75eb03af6b",
       "type": "setlist",
-      "category": "official_setlist",
+      "category": "yarn_setlist",
       "url": "https://releases.yarg.in/profiles/0d02d00e-eac4-4cdd-b92e-1e75eb03af6b/",
       "release": "2025-07-20T16:21:33.3063029Z",
       "name": "Plastic Death",
+      "subText": "Glass Beach",
       "iconUrl": "https://releases.yarg.in/profiles/0d02d00e-eac4-4cdd-b92e-1e75eb03af6b/icon.png",
       "bannerUrl": "https://releases.yarg.in/profiles/0d02d00e-eac4-4cdd-b92e-1e75eb03af6b/banner.png",
       "localeOverrides": {}
@@ -241,6 +245,7 @@
       "url": "https://releases.yarg.in/profiles/c0eb74f4-05df-4dfa-8ceb-b699ced444fc/",
       "release": "2025-07-25T16:19:46.1761723Z",
       "name": "The Slip",
+      "subText": "Nine Inch Nails",
       "iconUrl": "https://releases.yarg.in/profiles/c0eb74f4-05df-4dfa-8ceb-b699ced444fc/icon.png",
       "bannerUrl": "https://releases.yarg.in/profiles/c0eb74f4-05df-4dfa-8ceb-b699ced444fc/banner.png",
       "localeOverrides": {}


### PR DESCRIPTION
* Updated banner to Wave 11, added link to trailer video and updated the uuid
* Changed category for some profiles from "official_setlist" to "yarn_setlist"
    * This doesn't do anything in the current launcher, this is only used in the new launcher here: https://github.com/theli-ua/YARC-Launcher/pull/1
* Added badge strings to each profile
    * Again, not used in the current launcher yet, only in the new version. this is what decides what kind of badge to display on the profile screen