### PR TITLE
Update _redirects to include urls without trailing slashes

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,8 @@
 / /index.json
 
+/profiles /profiles/index.json
 /profiles/ /profiles/index.json
+/profiles/:profile_uuid /profiles/:profile_uuid/index.json
 /profiles/:profile_uuid/ /profiles/:profile_uuid/index.json
+/profiles/:profile_uuid/releases /profiles/:profile_uuid/releases.json
 /profiles/:profile_uuid/releases/ /profiles/:profile_uuid/releases.json


### PR DESCRIPTION
This should fix the issue of the launcher not working, as the URL: https://releases.yarg.in/profiles it should now properly redirect to https://releases.yarg.in/profiles/index.json